### PR TITLE
SQL DELETEクエリの修正：指定されたIDのユーザーを正しく削除

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -2,9 +2,4 @@ class User < ApplicationRecord
   has_many :training_days, dependent: :destroy
   has_many :training_sessions, dependent: :destroy
 
-  # validates :gender, presence: true
-  # validates :experience, presence: true
-  # validates :frequency, presence: true
-  # validates :duration, presence: true
-  # validates :level, presence: true
 end

--- a/db/migrate/20240519091435_remove_existing_foreign_key_from_training_days.rb
+++ b/db/migrate/20240519091435_remove_existing_foreign_key_from_training_days.rb
@@ -1,0 +1,5 @@
+class RemoveExistingForeignKeyFromTrainingDays < ActiveRecord::Migration[7.0]
+  def change
+    remove_foreign_key :training_days, name: "fk_rails_a5d156f0f9"
+  end
+end

--- a/db/migrate/20240519091505_add_cascade_delete_to_training_days.rb
+++ b/db/migrate/20240519091505_add_cascade_delete_to_training_days.rb
@@ -1,0 +1,5 @@
+class AddCascadeDeleteToTrainingDays < ActiveRecord::Migration[7.0]
+  def change
+    add_foreign_key :training_days, :users, on_delete: :cascade
+  end
+end

--- a/db/migrate/20240519092552_remove_foreign_key_from_training_menus.rb
+++ b/db/migrate/20240519092552_remove_foreign_key_from_training_menus.rb
@@ -1,0 +1,5 @@
+class RemoveForeignKeyFromTrainingMenus < ActiveRecord::Migration[7.0]
+  def change
+       remove_foreign_key :training_menus, :training_days
+  end
+end

--- a/db/migrate/20240519092609_add_cascade_delete_to_training_menus.rb
+++ b/db/migrate/20240519092609_add_cascade_delete_to_training_menus.rb
@@ -1,0 +1,5 @@
+class AddCascadeDeleteToTrainingMenus < ActiveRecord::Migration[7.0]
+  def change
+    add_foreign_key :training_menus, :training_days, on_delete: :cascade
+  end
+end

--- a/db/migrate/20240519092906_remove_foreign_key_from_training_sets.rb
+++ b/db/migrate/20240519092906_remove_foreign_key_from_training_sets.rb
@@ -1,0 +1,5 @@
+class RemoveForeignKeyFromTrainingSets < ActiveRecord::Migration[7.0]
+  def change
+    remove_foreign_key :training_sets, :training_menus
+  end
+end

--- a/db/migrate/20240519092925_add_cascade_delete_to_training_sets.rb
+++ b/db/migrate/20240519092925_add_cascade_delete_to_training_sets.rb
@@ -1,0 +1,5 @@
+class AddCascadeDeleteToTrainingSets < ActiveRecord::Migration[7.0]
+  def change
+    add_foreign_key :training_sets, :training_menus, on_delete: :cascade
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2024_05_05_073614) do
+ActiveRecord::Schema[7.0].define(version: 2024_05_19_092925) do
   create_table "todos", charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
     t.string "title"
     t.boolean "completed"
@@ -45,14 +45,14 @@ ActiveRecord::Schema[7.0].define(version: 2024_05_05_073614) do
   end
 
   create_table "training_sets", charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
-    t.bigint "exercise_id", null: false
     t.integer "set_number"
     t.integer "weight"
     t.integer "reps"
     t.boolean "completed"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
-    t.index ["exercise_id"], name: "index_training_sets_on_exercise_id"
+    t.bigint "training_menu_id", null: false
+    t.index ["training_menu_id"], name: "index_training_sets_on_training_menu_id"
   end
 
   create_table "users", charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
@@ -63,6 +63,7 @@ ActiveRecord::Schema[7.0].define(version: 2024_05_05_073614) do
     t.datetime "updated_at", null: false
   end
 
-  add_foreign_key "training_days", "users"
-  add_foreign_key "training_menus", "training_days"
+  add_foreign_key "training_days", "users", on_delete: :cascade
+  add_foreign_key "training_menus", "training_days", on_delete: :cascade
+  add_foreign_key "training_sets", "training_menus", on_delete: :cascade
 end


### PR DESCRIPTION
特定のIDのユーザーを削除するSQL DELETEクエリの修正を行います。以前のクエリ構文が誤っていたため、意図した複数のユーザーが削除されていなかった。

