### PR TITLE
Add date column to daily_programs and update date on save

### DIFF
--- a/app/controllers/api/v2/personalized_menus_controller.rb
+++ b/app/controllers/api/v2/personalized_menus_controller.rb
@@ -52,7 +52,8 @@ class Api::V2::PersonalizedMenusController < ApplicationController
         daily_program = program_bundle.daily_programs.build(
             week: prog[:week],
             day: day_counter,
-            details: prog[:details]
+            details: prog[:details],
+            date: nil
           )
           daily_program.save!
           Rails.logger.debug "Created daily_program: #{daily_program.inspect}"
@@ -95,6 +96,16 @@ class Api::V2::PersonalizedMenusController < ApplicationController
       render json: { program: program_json }, status: :created
     else
       render json: { errors: program_bundle.errors.full_messages }, status: :unprocessable_entity
+    end
+  end
+
+  def save_daily_program
+  daily_program = DailyProgram.find(params[:id])
+
+    if daily_program.update(date: Date.today)
+      render json: daily_program, status: :ok
+    else
+      render json: { errors: daily_program.errors.full_messages }, status: :unprocessable_entity
     end
   end
 

--- a/app/models/daily_program.rb
+++ b/app/models/daily_program.rb
@@ -4,4 +4,11 @@ class DailyProgram < ApplicationRecord
 
   validates :week, presence: true
   validates :day, presence: true, numericality: { only_integer: true, greater_than: 0 }
+  validates :unique_date_per_program_bundle, on: :update
+
+  def unique_date_per_program_bundle
+    if DailyProgram.where(program_bundle_id: program_bundle_id, week: week, day: day, date: date).exists?
+      errors.add(:date, "You can only create one daily program per day for this program bundle")
+    end
+  end
 end

--- a/db/migrate/20240619012313_add_date_to_daily_programs.rb
+++ b/db/migrate/20240619012313_add_date_to_daily_programs.rb
@@ -1,0 +1,5 @@
+class AddDateToDailyPrograms < ActiveRecord::Migration[7.0]
+  def change
+    add_column :daily_programs, :date, :date, null: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2024_06_12_113754) do
+ActiveRecord::Schema[7.0].define(version: 2024_06_19_012313) do
   create_table "daily_programs", charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
     t.json "details"
     t.datetime "created_at", null: false
@@ -19,6 +19,7 @@ ActiveRecord::Schema[7.0].define(version: 2024_06_12_113754) do
     t.integer "week", null: false
     t.boolean "completed", default: false, null: false
     t.integer "day"
+    t.date "date"
     t.index ["program_bundle_id", "week", "day"], name: "index_daily_programs_on_program_bundle_id_and_week_and_day", unique: true
   end
 


### PR DESCRIPTION
- Add `date` column to `daily_programs` table (nullable)
- Validate uniqueness of `date` within `program_bundle` on update
- Implement `save_daily_program` action to set current date on save