### PR TITLE
delete training_program.rb

### DIFF
--- a/app/models/training_program.rb
+++ b/app/models/training_program.rb
@@ -1,8 +1,0 @@
-class TrainingProgram < ApplicationRecord
-  belongs_to :user
-  has_many :training_menus, dependent: :destroy
-
-  scope :by_gender, ->(gender) { where(gender: gender) }
-  scope :by_frequency, ->(frequency) { where(frequency: frequency) }
-  scope :by_duration, ->(duration) { where('week <= ?', duration) }
-end


### PR DESCRIPTION
 training_programモデルは使用されておらず、不要なため削除します。